### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/scripts/coopLib.py
+++ b/scripts/coopLib.py
@@ -10,11 +10,22 @@
 @summary:       Maya cooperative python library
 @run:           import coopLib as lib (suggested)
 """
+from __future__ import print_function
 import os, sys, subprocess, shutil, logging, json, math, traceback
 from functools import wraps
 import maya.mel as mel
 import maya.cmds as cmds
 import maya.api.OpenMaya as om  # python api 2.0
+
+try:
+    basestring           # Python 2
+except NameError:
+    basestring = (str,)  # Python 3
+
+try:
+    xrange               # Python 2
+except NameError:
+    xrange = range       # Python 3
 
 # LOGGING
 logging.basicConfig()  # errors and everything else (2 separate log groups)
@@ -148,7 +159,7 @@ def restartMaya(brute=True):
         if cmds.about(nt=True, q=True):
             mayaPyDir += ".exe"
         scriptDir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "coopRestart.py")
-        print scriptDir
+        print(scriptDir)
         subprocess.Popen([mayaPyDir, scriptDir])
         cmds.quit(force=True)
     else:
@@ -214,7 +225,7 @@ def detachShelf():
         files = os.listdir(shelfPath)
         if shelfFile in files:
             shelfFilePath = os.path.join(shelfPath, shelfFile)
-    print shelfFilePath
+    print(shelfFilePath)
 
 
 def deleteShelves(shelvesDict=None):
@@ -373,7 +384,7 @@ def setAttr(obj, attr, value, silent=False):
         silent (bool): if the function is silent when errors occur
     """
     try:
-        if isinstance(value, unicode) or isinstance(value, str):
+        if isinstance(value, basestring):
             cmds.setAttr("{0}.{1}".format(obj, attr), value, type="string")
         elif isinstance(value, list) or isinstance(value, tuple):
             if len(value) == 3:
@@ -449,13 +460,13 @@ def snap(source='', targets=[], type="translation"):
         for target in targets:
             cmds.xform('{0}'.format(target), worldSpace=True,
                        t=(worldTranslateXform[0], worldTranslateXform[1], worldTranslateXform[2]))
-        print "Translation snapped",
+        print("Translation snapped", end=' ')
 
     if type == "rotation":
         sourceXform = cmds.xform('{0}'.format(source), q=True, worldSpace=True, ro=True)
         for target in targets:
             cmds.xform('{0}'.format(target), worldSpace=True, ro=(sourceXform[0], sourceXform[1], sourceXform[2]))
-        print "Rotation snapped",
+        print("Rotation snapped", end=' ')
 
     if type == "position":
         sourcePos = cmds.xform('{0}'.format(source), q=True, worldSpace=True, piv=True)  # list with 6 elements
@@ -463,7 +474,7 @@ def snap(source='', targets=[], type="translation"):
         for target in targets:
             cmds.xform('{0}'.format(target), worldSpace=True, t=(sourcePos[0], sourcePos[1], sourcePos[2]))
             cmds.xform('{0}'.format(target), worldSpace=True, ro=(sourceRot[0], sourceRot[1], sourceRot[2]))
-        print "Position snapped",
+        print("Position snapped", end=' ')
 
 
 ######################################################################################
@@ -550,7 +561,7 @@ def screenshot(fileDir, width, height, format=".jpg", override="", ogs=True):
     cmds.setAttr("defaultRenderGlobals.imageFormat", prevFormat)
     cmds.setAttr("hardwareRenderingGlobals.renderOverrideName", prevOverride, type="string")
 
-    print "Image saved successfully in {0}".format(fileDir),
+    print("Image saved successfully in {0}".format(fileDir), end=' ')
     return fileDir
 
 
@@ -576,7 +587,7 @@ def exportVertexColors(objs, path):
     shapeDict = {}
     shapes = getShapes(objs)
     for shape in shapes:
-        print "Extracting vertex colors from {0}".format(shape)
+        print("Extracting vertex colors from {0}".format(shape))
         shapeName = "{0}".format(shape)
 
         # check for namespaces
@@ -612,7 +623,7 @@ def exportVertexColors(objs, path):
     with open(path, 'w') as f:
         json.dump(shapeDict, f, separators=(',', ':'), indent=2)
 
-    print "Vertex colors successfully exported",
+    print("Vertex colors successfully exported", end=' ')
 
 
 def importVertexColors(path):
@@ -631,7 +642,7 @@ def importVertexColors(path):
 
     # assign vertex color parameters on each shape
     for shape in shapeDict:
-        print "Importing parameters to {0}".format(shape)
+        print("Importing parameters to {0}".format(shape))
         shapeName = "{0}".format(shape)
         if namespace:
             shapeName = "{0}:{1}".format(namespace, shapeName)
@@ -664,7 +675,7 @@ def importVertexColors(path):
                 fnMesh.setVertexColors(oVertexColorArray, vertexIndexArray)
         else:
             logger.debug("No {0} shape exists in the scene".format(shapeName))
-    print "Vertex colors successfully exported from {0}".format(os.path.basename(path)),
+    print("Vertex colors successfully exported from {0}".format(os.path.basename(path)), end=' ')
 
 
 #    __  __                           _    ____ ___     ____    ___

--- a/scripts/coopLib.py
+++ b/scripts/coopLib.py
@@ -460,13 +460,13 @@ def snap(source='', targets=[], type="translation"):
         for target in targets:
             cmds.xform('{0}'.format(target), worldSpace=True,
                        t=(worldTranslateXform[0], worldTranslateXform[1], worldTranslateXform[2]))
-        print("Translation snapped", end=' ')
+        printInfo("Translation snapped")
 
     if type == "rotation":
         sourceXform = cmds.xform('{0}'.format(source), q=True, worldSpace=True, ro=True)
         for target in targets:
             cmds.xform('{0}'.format(target), worldSpace=True, ro=(sourceXform[0], sourceXform[1], sourceXform[2]))
-        print("Rotation snapped", end=' ')
+        printInfo("Rotation snapped")
 
     if type == "position":
         sourcePos = cmds.xform('{0}'.format(source), q=True, worldSpace=True, piv=True)  # list with 6 elements
@@ -474,7 +474,7 @@ def snap(source='', targets=[], type="translation"):
         for target in targets:
             cmds.xform('{0}'.format(target), worldSpace=True, t=(sourcePos[0], sourcePos[1], sourcePos[2]))
             cmds.xform('{0}'.format(target), worldSpace=True, ro=(sourceRot[0], sourceRot[1], sourceRot[2]))
-        print("Position snapped", end=' ')
+        printInfo("Position snapped")
 
 
 ######################################################################################
@@ -561,7 +561,7 @@ def screenshot(fileDir, width, height, format=".jpg", override="", ogs=True):
     cmds.setAttr("defaultRenderGlobals.imageFormat", prevFormat)
     cmds.setAttr("hardwareRenderingGlobals.renderOverrideName", prevOverride, type="string")
 
-    print("Image saved successfully in {0}".format(fileDir), end=' ')
+    printInfo("Image saved successfully in {0}".format(fileDir))
     return fileDir
 
 
@@ -623,7 +623,7 @@ def exportVertexColors(objs, path):
     with open(path, 'w') as f:
         json.dump(shapeDict, f, separators=(',', ':'), indent=2)
 
-    print("Vertex colors successfully exported", end=' ')
+    printInfo("Vertex colors successfully exported")
 
 
 def importVertexColors(path):
@@ -675,7 +675,7 @@ def importVertexColors(path):
                 fnMesh.setVertexColors(oVertexColorArray, vertexIndexArray)
         else:
             logger.debug("No {0} shape exists in the scene".format(shapeName))
-    print("Vertex colors successfully exported from {0}".format(os.path.basename(path)), end=' ')
+    printInfo("Vertex colors successfully exported from {0}".format(os.path.basename(path)))
 
 
 #    __  __                           _    ____ ___     ____    ___
@@ -697,6 +697,15 @@ def getMObject(node):
     oNode = selectionList.getDependNode(0)
     # print "APItype of {0} is {1}".format(node, oNode.apiTypeStr)
     return oNode
+
+
+def printInfo(info):
+    """
+    Prints the information statement in the command response (to the right of the command line)
+    Args:
+        info (str): Information to be displayed
+    """
+    om.MGlobal.displayInfo(info)
 
 
 #                _   _

--- a/scripts/coopQt.py
+++ b/scripts/coopQt.py
@@ -10,12 +10,18 @@
 @summary:       Maya cooperative qt library
 @run:           import coopQt as qt (suggested)
 """
+from __future__ import print_function
 import logging, time, threading
 import maya.mel as mel
 import maya.cmds as cmds
 import maya.OpenMayaUI as omUI
 from PySide2 import QtCore, QtGui, QtWidgets
 from shiboken2 import wrapInstance
+
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
 
 # LOGGING
 logging.basicConfig()  # errors and everything else (2 separate log groups)
@@ -111,7 +117,7 @@ class CoopMayaUI(QtWidgets.QDialog):
 
         # check if the ui is dockable
         if cmds.dockControl(title, query=True, exists=True):
-            print "dock under this name exists"
+            print("dock under this name exists")
             cmds.deleteUI("watercolorFX", ctl=True)
             cmds.deleteUI("watercolorFX", lay=True)
         if dock:

--- a/scripts/mnpr_UIs.py
+++ b/scripts/mnpr_UIs.py
@@ -9,6 +9,7 @@
                  |_|
 @summary:       Contains the pass breakdown and MNPR viewport renderer interfaces
 """
+from __future__ import print_function
 import os
 from PySide2 import QtCore, QtWidgets
 import maya.cmds as cmds
@@ -144,18 +145,18 @@ class BreakdownUI(qt.CoopMayaUI):
             if cmds.mnpr(renderOperation=index) != prev:
                 changedOperation = index
         # give back information as to what the toggle is doing with mnpr
-        print "mnpr -renderOperation {0} -s {1};".format(changedOperation, int(self.sender().isChecked()))
+        print("mnpr -renderOperation {0} -s {1};".format(changedOperation, int(self.sender().isChecked())))
 
     def reloadOperationShaders(self):
         """ Reload shader of operation """
         operationIndex = self.sender().property("operationIndex")
         cmds.mnpr(rOS=operationIndex)
-        print "mnpr -rOS {0};".format(operationIndex)
+        print("mnpr -rOS {0};".format(operationIndex))
 
     def targetChanged(self):
         """ Change and visualize render target """
         cmds.mnpr(renderTarget=self.targetCoBox.currentIndex())
-        print "mnpr -renderTarget {0};".format(self.targetCoBox.currentIndex())
+        print("mnpr -renderTarget {0};".format(self.targetCoBox.currentIndex()))
 
     def channelsChanged(self):
         """ Enable/disable RGBA channels """
@@ -195,9 +196,9 @@ class BreakdownUI(qt.CoopMayaUI):
                 b = self.cChannels[2]
         cmds.mnpr(ch=(r * neg, g * neg, b * neg, a * neg))
         if not a:
-            print "mnpr -ch {0} {1} {2} {3}".format(r * neg, g * neg, b * neg, a * neg)
+            print("mnpr -ch {0} {1} {2} {3}".format(r * neg, g * neg, b * neg, a * neg))
         else:
-            print "mnpr -ch 0 0 0 {0}".format(a * neg)
+            print("mnpr -ch 0 0 0 {0}".format(a * neg))
 
     def colorTransformChanged(self, obj=0):
         """
@@ -211,7 +212,7 @@ class BreakdownUI(qt.CoopMayaUI):
         elif obj == self.colorTransform2:
             colorTransformMode = 2
         cmds.mnpr(ct=(colorTransformMode))
-        print "mnpr -ct {0};".format(colorTransformMode)
+        print("mnpr -ct {0};".format(colorTransformMode))
 
 
 #                       _
@@ -387,5 +388,5 @@ class ViewportRendererUI(qt.CoopMayaUI):
         if self.supersamplePlbChBox.isChecked():
             renderSize = 2
         # playblast timeline using npr system
-        print renderSize
+        print(renderSize)
         mnpr_system.playblast(saveDir, width, height, renderCamera, modelPanel, renderSize)

--- a/scripts/mnpr_matPresets.py
+++ b/scripts/mnpr_matPresets.py
@@ -9,6 +9,7 @@
                                             |_|
 @summary:       MNPR's material presets interface and implementation
 """
+from __future__ import print_function
 import os, json, logging, pprint, operator, traceback
 from PySide2 import QtWidgets, QtCore, QtGui
 import maya.cmds as cmds
@@ -275,7 +276,7 @@ def setMaterialAttrs(mat, matAttrs, options={}):
                 cmds.shaderfx(sfxnode=mat, edit_bool=(nodeId, "value", procSettings[setting]))
             except RuntimeError:
                 #traceback.print_exc()
-                print "Setting of {0} procedural node has failed".format(setting)
+                print("Setting of {0} procedural node has failed".format(setting))
                 continue
     # set all attributes
     if mnpr_system.updateAE():
@@ -316,7 +317,7 @@ class MnprMaterialLibrary(dict):
 
         # get material from selection
         mat, xforms = getMaterial(selection)
-        print mat, xforms
+        print(mat, xforms)
 
         cmds.select(xforms, r=True)
 
@@ -451,7 +452,7 @@ class MnprMaterialLibrary(dict):
             setMaterialAttrs(mat, self[name], options)
         else:
             # set attributes in material
-            print "->{0} will be replaced".format(mat)
+            print("->{0} will be replaced".format(mat))
             attrs = self[name]['attributes']
             for attr in attrs:
                 lib.setAttr(mat, attr, attrs[attr])
@@ -606,7 +607,7 @@ class MnprMaterialPresetsUI(qt.CoopMayaUI):
             return
 
         name = currentItem.text()
-        print name
+        print(name)
         options = {"newMaterial": self.newMaterialCBox.isChecked(),
                    "textures": self.withTexturesCBox.isChecked(),
                    "noiseFX": self.withNoiseFXCBox.isChecked()}

--- a/scripts/mnpr_nFX.py
+++ b/scripts/mnpr_nFX.py
@@ -10,6 +10,7 @@
 @summary:       NoiseFX classes and functions
                 NoiseFX is responsible for the material effect control
 """
+from __future__ import print_function
 import maya.cmds as cmds
 import coopLib as lib
 
@@ -221,15 +222,15 @@ def noiseTypeClicked(fx):
     # get node names of operation
     sfxNodes = getNodeNames(fx, 0)
 
-    print "Recompiling material",
+    print("Recompiling material", end=' ')
     typeId = getId(materials[0], sfxNodes.typeNodeName)  # base toggle on first material state
     state = cmds.shaderfx(sfxnode=materials[0], getPropertyValue=(typeId, "value"))
     for mat in materials:
         cmds.shaderfx(sfxnode=mat, edit_bool=(typeId, "value", not state))
     if state:
-        print "\nNoiseFX for {0} is now in 2D".format(fx.description),
+        print("\nNoiseFX for {0} is now in 2D".format(fx.description), end=' ')
     else:
-        print "\nNoiseFX for {0} is now in 3D".format(fx.description),
+        print("\nNoiseFX for {0} is now in 3D".format(fx.description), end=' ')
 
 
 def noiseToggleClicked(fx):
@@ -243,16 +244,16 @@ def noiseToggleClicked(fx):
     # get node names of operation
     sfxNodes = getNodeNames(fx, 0)
 
-    print "Recompiling material",
+    print("Recompiling material", end=' ')
     stateId = getId(materials[0], sfxNodes.stateNodeName)  # base toggle on first material state
     state = cmds.shaderfx(sfxnode=materials[0], getPropertyValue=(stateId, "value"))
     for mat in materials:
         stateId = getId(mat, sfxNodes.stateNodeName)
         cmds.shaderfx(sfxnode=mat, edit_bool=(stateId, "value", not state))
     if state:
-        print "\nNoiseFX for {0} is off".format(fx.description),
+        print("\nNoiseFX for {0} is off".format(fx.description), end=' ')
     else:
-        print "\nNoiseFX for {0} is on".format(fx.description),
+        print("\nNoiseFX for {0} is on".format(fx.description), end=' ')
 
 
 def noiseSlide(fx, widget):
@@ -283,7 +284,7 @@ def noiseSlide(fx, widget):
         # turn on procedural noise if turned off
         stateId = getId(mat, sfxNodes.stateNodeName)
         if not cmds.shaderfx(sfxnode=mat, getPropertyValue=(stateId, "value")):
-            print "Recompiling material",
+            print("Recompiling material", end=' ')
             cmds.shaderfx(sfxnode=mat, edit_bool=(stateId, "value", True))
 
         # get attribute name
@@ -337,7 +338,7 @@ def noiseReset(fx):
     # get node names of operation
     sfxNodes = getNodeNames(fx, 0)
 
-    print "Recompiling material",
+    print("Recompiling material", end=' ')
 
     # reset each material
     materials = getMaterials()
@@ -354,4 +355,4 @@ def noiseReset(fx):
         cmds.shaderfx(sfxnode=mat, edit_float=(sfxNodes.shift, "value", 0.0))
         cmds.shaderfx(sfxnode=mat, edit_bool=(sfxNodes.scale, "value", True))
 
-    print "{0} procedural control has been reset".format(fx.description),
+    print("{0} procedural control has been reset".format(fx.description), end=' ')

--- a/scripts/mnpr_nFX.py
+++ b/scripts/mnpr_nFX.py
@@ -222,15 +222,15 @@ def noiseTypeClicked(fx):
     # get node names of operation
     sfxNodes = getNodeNames(fx, 0)
 
-    print("Recompiling material", end=' ')
+    lib.printInfo("Recompiling material")
     typeId = getId(materials[0], sfxNodes.typeNodeName)  # base toggle on first material state
     state = cmds.shaderfx(sfxnode=materials[0], getPropertyValue=(typeId, "value"))
     for mat in materials:
         cmds.shaderfx(sfxnode=mat, edit_bool=(typeId, "value", not state))
     if state:
-        print("\nNoiseFX for {0} is now in 2D".format(fx.description), end=' ')
+        lib.printInfo("NoiseFX for {0} is now in 2D".format(fx.description))
     else:
-        print("\nNoiseFX for {0} is now in 3D".format(fx.description), end=' ')
+        lib.printInfo("NoiseFX for {0} is now in 3D".format(fx.description))
 
 
 def noiseToggleClicked(fx):
@@ -244,16 +244,16 @@ def noiseToggleClicked(fx):
     # get node names of operation
     sfxNodes = getNodeNames(fx, 0)
 
-    print("Recompiling material", end=' ')
+    lib.printInfo("Recompiling material")
     stateId = getId(materials[0], sfxNodes.stateNodeName)  # base toggle on first material state
     state = cmds.shaderfx(sfxnode=materials[0], getPropertyValue=(stateId, "value"))
     for mat in materials:
         stateId = getId(mat, sfxNodes.stateNodeName)
         cmds.shaderfx(sfxnode=mat, edit_bool=(stateId, "value", not state))
     if state:
-        print("\nNoiseFX for {0} is off".format(fx.description), end=' ')
+        lib.printInfo("NoiseFX for {0} is off".format(fx.description))
     else:
-        print("\nNoiseFX for {0} is on".format(fx.description), end=' ')
+        lib.printInfo("NoiseFX for {0} is on".format(fx.description))
 
 
 def noiseSlide(fx, widget):
@@ -284,7 +284,7 @@ def noiseSlide(fx, widget):
         # turn on procedural noise if turned off
         stateId = getId(mat, sfxNodes.stateNodeName)
         if not cmds.shaderfx(sfxnode=mat, getPropertyValue=(stateId, "value")):
-            print("Recompiling material", end=' ')
+            lib.printInfo("Recompiling material")
             cmds.shaderfx(sfxnode=mat, edit_bool=(stateId, "value", True))
 
         # get attribute name
@@ -338,7 +338,7 @@ def noiseReset(fx):
     # get node names of operation
     sfxNodes = getNodeNames(fx, 0)
 
-    print("Recompiling material", end=' ')
+    lib.printInfo("Recompiling material")
 
     # reset each material
     materials = getMaterials()
@@ -355,4 +355,4 @@ def noiseReset(fx):
         cmds.shaderfx(sfxnode=mat, edit_float=(sfxNodes.shift, "value", 0.0))
         cmds.shaderfx(sfxnode=mat, edit_bool=(sfxNodes.scale, "value", True))
 
-    print("{0} procedural control has been reset".format(fx.description), end=' ')
+    lib.printInfo("{0} procedural control has been reset".format(fx.description))

--- a/scripts/mnpr_pFX.py
+++ b/scripts/mnpr_pFX.py
@@ -11,6 +11,7 @@
                 PaintFX is responsible for the mapped effect control
 
 """
+from __future__ import print_function
 import os, math, logging
 import maya.cmds as cmds
 import maya.mel as mel
@@ -18,6 +19,11 @@ import maya.api.OpenMaya as om  # python api 2.0
 import coopLib as lib
 import mnpr_system
 import mnpr_info
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 logging.basicConfig()  # errors and everything else (2 separate log groups)
 logger = logging.getLogger("pFX")  # create a logger for this file
@@ -115,7 +121,7 @@ def defaultVertexColors(shape):
         oVertexColorArray[vertex].a = 0.0
     fnMesh.setCurrentColorSetName('controlSetC')
     fnMesh.setVertexColors(oVertexColorArray, vertexIndexArray)
-    print "vertex colors should have been set"
+    print("vertex colors should have been set")
 
 
 @lib.timer
@@ -247,7 +253,7 @@ def translateVtxCtrl(shape):
             oVertexColorArrayC[vertex].a = max((blue - 0.5) * 2.0, 0.0)
         fnMesh.setCurrentColorSetName('controlSetC')
         fnMesh.setVertexColors(oVertexColorArrayC, vertexIndexArray)
-        print "Control parameters changed in shape: {0}".format(shape)
+        print("Control parameters changed in shape: {0}".format(shape))
     else:
         logger.info("{0} has not been prepped, skipping.".format(shape))
 

--- a/scripts/mnpr_presets.py
+++ b/scripts/mnpr_presets.py
@@ -180,7 +180,7 @@ class AttributeSetsLibrary(dict):
                 if "NPRConfig" in splitter[0]:
                     splitter[0] = "mnprConfig"
                 lib.setAttr(splitter[0], splitter[1], attrs[attr])
-        print("Attributes set successfully", end=' ')
+        lib.printInfo("Attributes set successfully")
 
     def loadStyle(self, attrs):
         if cmds.objExists(mnpr_info.configNode):
@@ -188,7 +188,7 @@ class AttributeSetsLibrary(dict):
             for attr in attrs:
                 splitter = attr.split('.')
                 lib.setAttr(splitter[0], splitter[1], attrs[attr], True)
-            print("\nStyle changed and attributes set successfully", end=' ')
+            lib.printInfo("Style changed and attributes set successfully")
 
     def saveScreenshot(self, name, directory):
         """

--- a/scripts/mnpr_presets.py
+++ b/scripts/mnpr_presets.py
@@ -10,6 +10,7 @@
 @summary:       MNPR's style presets interface and implementation
 @adapted from:  coopAttrManager.py (https://github.com/semontesdeoca/maya-coop)
 """
+from __future__ import print_function
 import os, json, logging, pprint, operator, traceback, functools
 from PySide2 import QtWidgets, QtCore, QtGui
 import maya.cmds as cmds
@@ -179,7 +180,7 @@ class AttributeSetsLibrary(dict):
                 if "NPRConfig" in splitter[0]:
                     splitter[0] = "mnprConfig"
                 lib.setAttr(splitter[0], splitter[1], attrs[attr])
-        print "Attributes set successfully",
+        print("Attributes set successfully", end=' ')
 
     def loadStyle(self, attrs):
         if cmds.objExists(mnpr_info.configNode):
@@ -187,7 +188,7 @@ class AttributeSetsLibrary(dict):
             for attr in attrs:
                 splitter = attr.split('.')
                 lib.setAttr(splitter[0], splitter[1], attrs[attr], True)
-            print "\nStyle changed and attributes set successfully",
+            print("\nStyle changed and attributes set successfully", end=' ')
 
     def saveScreenshot(self, name, directory):
         """

--- a/scripts/mnpr_runner.py
+++ b/scripts/mnpr_runner.py
@@ -9,6 +9,7 @@
                  |_|
 @summary:   A centralized file to run functions from the shelf
 """
+from __future__ import print_function
 from PySide2 import QtWidgets
 from shiboken2 import wrapInstance
 import maya.OpenMayaUI as omUI
@@ -20,6 +21,16 @@ import mnpr_system
 import mnpr_info
 import mnpr_UIs
 import mnpr_FX
+
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
+
+try:
+    long           # Python 2
+except NameError:
+    long = int     # Python 3
 
 
 def openPresets(rebuild=True):
@@ -65,7 +76,7 @@ def openNoiseFX(dock=False, rebuild=False):
     """
     fxType = "material-space"
     mnpr_system.check()
-    print "Opening noiseFX with dock = {0}".format(dock)
+    print("Opening noiseFX with dock = {0}".format(dock))
     windowObj = mnpr_FX.MNPR_FX_UI(dock=dock, rebuild=rebuild, tab=fxType)
 
     # change tab
@@ -86,7 +97,7 @@ def openPaintFX(dock=False, rebuild=False):
     # temporary workaround to painting ceasing to work correctly
     if rebuild:
         reload(mnpr_FX)
-    print "Opening paintFX with dock = {0}".format(dock)
+    print("Opening paintFX with dock = {0}".format(dock))
     windowObj = mnpr_FX.MNPR_FX_UI(dock=dock, rebuild=rebuild, tab=fxType)
 
     # change tab
@@ -142,7 +153,7 @@ def testScene(prototype="shaderFX"):
     testSphere = cmds.ls(sl=True)
     mnpr_matPresets.createMaterial(testSphere, prototype=prototype)
     mnpr_matPresets.defaultLighting()
-    print "Default scene created",
+    print("Default scene created", end=' ')
 
 
 def downloadSubstrates():

--- a/scripts/mnpr_runner.py
+++ b/scripts/mnpr_runner.py
@@ -15,6 +15,7 @@ from shiboken2 import wrapInstance
 import maya.OpenMayaUI as omUI
 import maya.cmds as cmds
 import maya.mel as mel
+import coopLib as lib
 import mnpr_presets
 import mnpr_matPresets
 import mnpr_system
@@ -153,7 +154,7 @@ def testScene(prototype="shaderFX"):
     testSphere = cmds.ls(sl=True)
     mnpr_matPresets.createMaterial(testSphere, prototype=prototype)
     mnpr_matPresets.defaultLighting()
-    print("Default scene created", end=' ')
+    lib.printInfo("Default scene created")
 
 
 def downloadSubstrates():

--- a/scripts/mnpr_setup.py
+++ b/scripts/mnpr_setup.py
@@ -9,6 +9,7 @@
                  |_|                               |_|
 @summary:       This file installs MNPR by adding the required file directories into the Maya.env file
 """
+from __future__ import print_function
 import os, shutil, urllib, pprint
 import maya.cmds as cmds
 import maya.mel as mel
@@ -40,7 +41,7 @@ if localOS == "linux":
 
 # SETTLE OS DEPENDENT DIRECTORIES
 pluginDir = "plugins/{0}/{1}/".format(mayaV, localOS)
-print pluginDir
+print(pluginDir)
 
 
 def run(root):
@@ -49,7 +50,7 @@ def run(root):
     Args:
         root: root directory of MNPR
     """
-    print "-> Installing MNPR"
+    print("-> Installing MNPR")
     variables = {'MAYA_SHELF_PATH': [os.path.abspath(os.path.join(root, "shelves/"))],
                  'MAYA_SCRIPT_PATH': [os.path.abspath(os.path.join(root, "scripts/"))],
                  'PYTHONPATH': [os.path.abspath(os.path.join(root, "scripts/"))],
@@ -69,7 +70,7 @@ def run(root):
 
     # get Maya environment variables
     envVariables = getEnvironmentVariables(mayaEnvFilePath)
-    print "ENVIRONMENT VARIABLES:"
+    print("ENVIRONMENT VARIABLES:")
     pprint.pprint(envVariables)
 
     # check if MNPR is already installed
@@ -78,7 +79,7 @@ def run(root):
 
     # merge mnpr variables
     envVariables = mergeVariables(variables, envVariables)
-    print "MODIFIED VARIABLES:"
+    print("MODIFIED VARIABLES:")
     pprint.pprint(envVariables)
 
     # write environment variables
@@ -97,7 +98,7 @@ def run(root):
     # get plugin for os
     getPlugin(variables)
 
-    print "-> Installation complete",
+    print("-> Installation complete", end=' ')
 
     # restart maya
     cmds.confirmDialog(title='Restart Maya',
@@ -171,11 +172,11 @@ def installationCheck(variables, envVariables):
         reply = cmds.confirmDialog(title='Overriding existing installation', message=mString, button=['Yes', 'No'], defaultButton='Yes', cancelButton='No', dismissString='No', icn="warning")
         # don't do anything
         if reply == "No":
-            print "-> Nothing was done to your current installation",
+            print("-> Nothing was done to your current installation", end=' ')
             return False
         # delete mnpr paths
         previousPath = "{0}".format(envVariables[mnprVariable][0])
-        print "Deleting previous MNPR installation at : {0}".format(previousPath)
+        print("Deleting previous MNPR installation at : {0}".format(previousPath))
         for key in envVariables:
             for value in envVariables[key]:
                 if previousPath in str(value):
@@ -192,7 +193,7 @@ def mergeVariables(variables, envVariables):
     Returns:
         envVariables (dict)
     """
-    print ""
+    print("")
     for var in variables:
         if var not in envVariables:
             # no variable existed, add
@@ -202,12 +203,12 @@ def mergeVariables(variables, envVariables):
             for varValue in variables[var]:
                 # for each variable value to add
                 if varValue in envVariables[var]:
-                    print "{0}={1} is already set as an environment variable.".format(var, varValue)
+                    print("{0}={1} is already set as an environment variable.".format(var, varValue))
                 else:
                     # variable did not exist, insert in front
                     envVariables[var].insert(0, varValue)
                     # (optional) check for clashes of files with other variables
-    print "Variables successfully updated.\n"
+    print("Variables successfully updated.\n")
     return envVariables
 
 
@@ -254,8 +255,8 @@ def getPlugin(variables):
         pluginURL += "/{0}".format(pluginName)  # add plugin name
 
         # get plugin file online
-        print "Getting plugin from: {0}".format(pluginURL)
-        print "Downloading plugin...",
+        print("Getting plugin from: {0}".format(pluginURL))
+        print("Downloading plugin...", end=' ')
         downloader = urllib.URLopener()
         downloader.retrieve(pluginURL, os.path.join(pluginDir, pluginName))
 
@@ -272,7 +273,7 @@ def getSubstrates():
             lib.openUrl(url)
             return
         else:
-            print "No substrates will be downloaded.",
+            print("No substrates will be downloaded.", end=' ')
             return
     # windows and linux
     import zipfile
@@ -282,19 +283,19 @@ def getSubstrates():
         lib.openUrl(url)
         return
     elif result == "Close":
-        print "No substrates will be downloaded.",
+        print("No substrates will be downloaded.", end=' ')
         return
     else:
         p = lib.Path(lib.getLibDir())
         p.parent().child("textures")
         dest = os.path.join(p.path, "seamless_textures_light.zip")
         if lib.downloader(url, dest):
-            print "Substrates downloaded, extracting..."
+            print("Substrates downloaded, extracting...")
             zip = zipfile.ZipFile(dest, 'r')
             zip.extractall(p.path)
             zip.close()
             os.remove(dest)
-            print "MNPR substrates installed successfully",
+            print("MNPR substrates installed successfully", end=' ')
             cmds.confirmDialog(t="Download successful", m="The substrates downloaded successfully", b="Yay!", icn="information")
         else:
             cmds.warning("Problem downloading substrates, please download and install manually")

--- a/scripts/mnpr_setup.py
+++ b/scripts/mnpr_setup.py
@@ -98,7 +98,7 @@ def run(root):
     # get plugin for os
     getPlugin(variables)
 
-    print("-> Installation complete", end=' ')
+    lib.printInfo("-> Installation complete")
 
     # restart maya
     cmds.confirmDialog(title='Restart Maya',
@@ -172,7 +172,7 @@ def installationCheck(variables, envVariables):
         reply = cmds.confirmDialog(title='Overriding existing installation', message=mString, button=['Yes', 'No'], defaultButton='Yes', cancelButton='No', dismissString='No', icn="warning")
         # don't do anything
         if reply == "No":
-            print("-> Nothing was done to your current installation", end=' ')
+            lib.printInfo("-> Nothing was done to your current installation")
             return False
         # delete mnpr paths
         previousPath = "{0}".format(envVariables[mnprVariable][0])
@@ -256,7 +256,7 @@ def getPlugin(variables):
 
         # get plugin file online
         print("Getting plugin from: {0}".format(pluginURL))
-        print("Downloading plugin...", end=' ')
+        lib.printInfo("Downloading plugin...")
         downloader = urllib.URLopener()
         downloader.retrieve(pluginURL, os.path.join(pluginDir, pluginName))
 
@@ -273,7 +273,7 @@ def getSubstrates():
             lib.openUrl(url)
             return
         else:
-            print("No substrates will be downloaded.", end=' ')
+            lib.printInfo("No substrates will be downloaded.")
             return
     # windows and linux
     import zipfile
@@ -283,7 +283,7 @@ def getSubstrates():
         lib.openUrl(url)
         return
     elif result == "Close":
-        print("No substrates will be downloaded.", end=' ')
+        lib.printInfo("No substrates will be downloaded.")
         return
     else:
         p = lib.Path(lib.getLibDir())
@@ -295,7 +295,7 @@ def getSubstrates():
             zip.extractall(p.path)
             zip.close()
             os.remove(dest)
-            print("MNPR substrates installed successfully", end=' ')
+            lib.printInfo("MNPR substrates installed successfully")
             cmds.confirmDialog(t="Download successful", m="The substrates downloaded successfully", b="Yay!", icn="information")
         else:
             cmds.warning("Problem downloading substrates, please download and install manually")

--- a/scripts/mnpr_system.py
+++ b/scripts/mnpr_system.py
@@ -81,7 +81,7 @@ def check():
         selectConfig()
         cmds.select(selected, r=True)
 
-    print("-> SYSTEM CHECK SUCCESSFUL\n", end=' ')
+    lib.printInfo("-> SYSTEM CHECK SUCCESSFUL")
 
 
 def changeStyle():
@@ -115,7 +115,7 @@ def changeStyle():
     if cmds.window(mnpr_FX.MNPR_FX_UI.windowTitle, exists=True):
         mnpr_runner.openPaintFX(rebuild=True)
 
-    print("Style changed", end=' ')
+    lib.printInfo("Style changed")
 
 
 def togglePlugin(force=""):
@@ -149,7 +149,7 @@ def unloadPlugin(plugin):
             cmds.delete(mnpr_info.configNode)  # delete config node
         cmds.flushUndo()  # clear undo queue
         cmds.unloadPlugin(plugin)  # unload plugin
-        print("->PLUGIN SUCCESSFULLY UNLOADED\n", end=' ')
+        lib.printInfo("->PLUGIN SUCCESSFULLY UNLOADED")
 
 
 def showShaderAttr():
@@ -176,7 +176,7 @@ def refreshShaders():
 
     for shader in shaders:
         cmds.setAttr("{0}.shader".format(shader), shaderFile, type="string")
-    print('Shaders refreshed', end=' ')
+    lib.printInfo('Shaders refreshed')
     return True
 
 
@@ -202,7 +202,7 @@ def updateShaderFX():
         print("{0} has been updated to the latest version".format(mat))
         print("{0}/{1} materials updated".format(counter, len(materials)))
 
-    print('Shaders updated', end=' ')
+    lib.printInfo('Shaders updated')
 
 
 def dx112glsl():
@@ -348,11 +348,11 @@ def selectConfig():
 
         cmds.connectAttr("{0}.evaluate".format(mnpr_info.configNode), "persp.visibility", f=True)
         mel.eval("AttributeEditor")
-        print("-> CONFIG NODE CREATED AND CONNECTED\n", end=' ')
+        lib.printInfo("-> CONFIG NODE CREATED AND CONNECTED")
     else:
         cmds.select(mnpr_info.configNode)
         mel.eval("AttributeEditor")
-        print("Selected {0} configuration node\n".format(mnpr_info.prototype), end=' ')
+        lib.printInfo("Selected {0} configuration node".format(mnpr_info.prototype))
 
 
 def optimizePerformance():
@@ -468,7 +468,7 @@ def playblast(saveDir, width, height, renderCamera, modelPanel, renderSize=1):
     cmds.mnpr(g=False)
     cmds.refresh()
 
-    print("Video has been successfully playblasted to: {0}".format(saveDir), end=' ')
+    lib.printInfo("Video has been successfully playblasted to: {0}".format(saveDir))
 
 
 def resolutionCheck(width, height, renderSize=1.0):

--- a/scripts/mnpr_system.py
+++ b/scripts/mnpr_system.py
@@ -9,6 +9,7 @@
                  |_|                 |___/
 @summary:       MNPR related functions
 """
+from __future__ import print_function
 import os
 import traceback
 import maya.cmds as cmds
@@ -53,7 +54,7 @@ dx2sfxAttr = {"xUseColorTexture": "Albedo_Texture",
 
 def check():
     """Makes sure everything is running right"""
-    print "SYSTEM CHECK FOR {0}".format(mnpr_info.prototype)
+    print("SYSTEM CHECK FOR {0}".format(mnpr_info.prototype))
     # check viewport
     viewport = lib.getActiveModelPanel()
     cmds.modelEditor(viewport, dtx=True, e=True)  # display textures
@@ -80,7 +81,7 @@ def check():
         selectConfig()
         cmds.select(selected, r=True)
 
-    print "-> SYSTEM CHECK SUCCESSFUL\n",
+    print("-> SYSTEM CHECK SUCCESSFUL\n", end=' ')
 
 
 def changeStyle():
@@ -93,7 +94,7 @@ def changeStyle():
         cmds.delete(mnpr_info.configNode)
     # flush undo
     cmds.flushUndo()
-    print "style deleted"
+    print("style deleted")
     # deregister node
     cmds.mnpr(rn=False)
     # register node
@@ -114,7 +115,7 @@ def changeStyle():
     if cmds.window(mnpr_FX.MNPR_FX_UI.windowTitle, exists=True):
         mnpr_runner.openPaintFX(rebuild=True)
 
-    print "Style changed",
+    print("Style changed", end=' ')
 
 
 def togglePlugin(force=""):
@@ -148,7 +149,7 @@ def unloadPlugin(plugin):
             cmds.delete(mnpr_info.configNode)  # delete config node
         cmds.flushUndo()  # clear undo queue
         cmds.unloadPlugin(plugin)  # unload plugin
-        print "->PLUGIN SUCCESSFULLY UNLOADED\n",
+        print("->PLUGIN SUCCESSFULLY UNLOADED\n", end=' ')
 
 
 def showShaderAttr():
@@ -175,7 +176,7 @@ def refreshShaders():
 
     for shader in shaders:
         cmds.setAttr("{0}.shader".format(shader), shaderFile, type="string")
-    print 'Shaders refreshed',
+    print('Shaders refreshed', end=' ')
     return True
 
 
@@ -198,40 +199,40 @@ def updateShaderFX():
         # set attributes
         mnpr_matPresets.setMaterialAttrs(mat, matAttrs)
 
-        print "{0} has been updated to the latest version".format(mat)
-        print "{0}/{1} materials updated".format(counter, len(materials))
+        print("{0} has been updated to the latest version".format(mat))
+        print("{0}/{1} materials updated".format(counter, len(materials)))
 
-    print 'Shaders updated',
+    print('Shaders updated', end=' ')
 
 
 def dx112glsl():
     """ Converts dx11 materials to glsl materials """
     check()
     dx11Shaders = cmds.ls(type="dx11Shader")
-    print dx11Shaders
+    print(dx11Shaders)
     for dx11Shader in dx11Shaders:
-        print "Transfering {0} shader".format(dx11Shader)
+        print("Transfering {0} shader".format(dx11Shader))
         # get all attributes
         attributes = cmds.listAttr(dx11Shader, ud=True, st="x*", k=True)
-        print attributes
+        print(attributes)
         # get all connected nodes
         connectedNodes = cmds.listConnections(dx11Shader, t="file", c=True, p=True)
-        print connectedNodes
+        print(connectedNodes)
         # get all shapes
         cmds.select(dx11Shader, r=True)
         cmds.hyperShade(objects="")
         shapes = cmds.ls(sl=True)
-        print shapes
+        print(shapes)
     
         # create glsl shader
         shader = cmds.shadingNode('GLSLShader', asShader=True, n="{0}_GL".format(dx11Shader))
         cmds.select(shapes, r=True)
         cmds.hyperShade(assign=shader)
-        print ">>> Shader {0} created".format(shader)
+        print(">>> Shader {0} created".format(shader))
         # assign attributes
         shaderFile = os.path.join(mnpr_info.environment,"shaders","PrototypeC.ogsfx")
         cmds.setAttr("{0}.shader".format(shader), shaderFile, type="string")
-        print "Setting attributes for {0}".format(shader)
+        print("Setting attributes for {0}".format(shader))
         for attr in attributes:
             value = cmds.getAttr("{0}.{1}".format(dx11Shader, attr))
             try:
@@ -240,7 +241,7 @@ def dx112glsl():
                 else:
                     cmds.setAttr("{0}.{1}".format(shader, attr), value)
             except:
-                print "Found problemt when setting {0}.{1}, skipping for now".format(shader, attr)
+                print("Found problemt when setting {0}.{1}, skipping for now".format(shader, attr))
         # connect nodes
         if connectedNodes:
             for i in range(0, len(connectedNodes), 2):
@@ -272,18 +273,18 @@ def dx112sfx(graph="mnpr_uber"):
             continue
         prototypeCNodes.append(dx11Shader)
 
-        print "Converting {0} shader".format(dx11Shader)
+        print("Converting {0} shader".format(dx11Shader))
         # get all attributes
         attributes = cmds.listAttr(dx11Shader, ud=True, st="x*", k=True)
-        print attributes
+        print(attributes)
         # get all connected nodes
         connectedNodes = cmds.listConnections(dx11Shader, t="file", c=True)
-        print connectedNodes
+        print(connectedNodes)
         # get all shapes
         cmds.select(dx11Shader, r=True)
         cmds.hyperShade(objects="")
         shapes = cmds.ls(sl=True)
-        print shapes
+        print(shapes)
 
         # create shaderFX shader
         shader = cmds.shadingNode('ShaderfxShader', asShader=True, name="{0}".format(dx11Shader.replace("_WC", "_SFX")))
@@ -291,7 +292,7 @@ def dx112sfx(graph="mnpr_uber"):
         cmds.hyperShade(assign=shader)
         shaderFile = os.path.join(mnpr_info.environment, "shaders", "{0}.sfx".format(graph))
         cmds.shaderfx(sfxnode=shader, loadGraph=shaderFile)
-        print ">>> Shader {0} created".format(shader)
+        print(">>> Shader {0} created".format(shader))
         # assign settings
         vtxControl = bool(cmds.getAttr("{0}.{1}".format(dx11Shader, "xUseControl")))
         if vtxControl:
@@ -306,7 +307,7 @@ def dx112sfx(graph="mnpr_uber"):
             nodeId = cmds.shaderfx(sfxnode=shader, getNodeIDByName="Specularity")
             cmds.shaderfx(sfxnode=shader, edit_bool=(nodeId, "value", specularity))
         # assign attributes
-        print "Setting attributes for {0}".format(shader)
+        print("Setting attributes for {0}".format(shader))
         for attr in attributes:
             value = cmds.getAttr("{0}.{1}".format(dx11Shader, attr))
             if attr in dx2sfxAttr:
@@ -342,16 +343,16 @@ def selectConfig():
         cmds.delete("NPRConfig")
 
     if not cmds.objExists(mnpr_info.configNode):
-        print mnpr_info.configNode
+        print(mnpr_info.configNode)
         cmds.createNode("mnprConfig", n=mnpr_info.configNode)
 
         cmds.connectAttr("{0}.evaluate".format(mnpr_info.configNode), "persp.visibility", f=True)
         mel.eval("AttributeEditor")
-        print "-> CONFIG NODE CREATED AND CONNECTED\n",
+        print("-> CONFIG NODE CREATED AND CONNECTED\n", end=' ')
     else:
         cmds.select(mnpr_info.configNode)
         mel.eval("AttributeEditor")
-        print "Selected {0} configuration node\n".format(mnpr_info.prototype),
+        print("Selected {0} configuration node\n".format(mnpr_info.prototype), end=' ')
 
 
 def optimizePerformance():
@@ -393,7 +394,7 @@ def renderFrame(saveDir, width, height, renderSize=1, imgFormat=".jpg", override
     try:
         screenshotPath = lib.screenshot(saveDir, width, height, format=imgFormat, override=override)  # render the frame
     except WindowsError:
-        print "Screenshot saving has been canceled"
+        print("Screenshot saving has been canceled")
     except:
         traceback.print_exc()
 
@@ -467,7 +468,7 @@ def playblast(saveDir, width, height, renderCamera, modelPanel, renderSize=1):
     cmds.mnpr(g=False)
     cmds.refresh()
 
-    print "Video has been successfully playblasted to: {0}".format(saveDir),
+    print("Video has been successfully playblasted to: {0}".format(saveDir), end=' ')
 
 
 def resolutionCheck(width, height, renderSize=1.0):

--- a/scripts/mnpr_updater.py
+++ b/scripts/mnpr_updater.py
@@ -9,6 +9,7 @@
                  |_|                  |_|
 @summary:       MNPR's automatic updated (beta)
 """
+from __future__ import print_function
 import maya.cmds as cmds
 import os, urllib, pprint, json
 import coopLib as lib
@@ -29,9 +30,9 @@ def updateMNPR(directory, files2Update, files2Delete):
     Returns:
         True if update successful
     """
-    print "\nUpdating files at {0}".format(directory)
-    print "Files to update: {0}".format(files2Update)
-    print "Files to delete: {0}".format(files2Delete)
+    print("\nUpdating files at {0}".format(directory))
+    print("Files to update: {0}".format(files2Update))
+    print("Files to delete: {0}".format(files2Delete))
 
     # unload MNPR
     mnpr_system.unloadPlugin(mnpr_info.prototype)
@@ -40,12 +41,12 @@ def updateMNPR(directory, files2Update, files2Delete):
     downloader = urllib.URLopener()
     for f in files2Update:
         onlineURL = "{0}{1}".format(distURL, f)
-        print "Downloading {0}".format(onlineURL)
+        print("Downloading {0}".format(onlineURL))
         filePath = os.path.abspath(os.path.join(directory, f.lstrip('/')))
         try:
             downloader.retrieve(onlineURL, filePath)
         except IOError:
-            print "Error: Couldn't download {0} into {1}".format(onlineURL, filePath)
+            print("Error: Couldn't download {0} into {1}".format(onlineURL, filePath))
             continue
         # after download, reload modules
         try:
@@ -53,18 +54,18 @@ def updateMNPR(directory, files2Update, files2Delete):
             exec("reload({0})".format(module))
         except NameError:
             pass
-        print "Download successful"
+        print("Download successful")
 
     # delete deprecated files
     for f in files2Delete:
         filePath = os.path.abspath(os.path.join(directory, f.lstrip('/')))
-        print "Deleting {0}".format(filePath)
+        print("Deleting {0}".format(filePath))
         try:
             os.remove(filePath)
         except:
-            print "Couldn't remove {0}".format(filePath)
+            print("Couldn't remove {0}".format(filePath))
 
-    print "Update completed.",
+    print("Update completed.", end=' ')
     return True
 
 
@@ -96,7 +97,7 @@ def createVersion(directory):
     # write and save json info
     with open(path, 'w') as f:
         json.dump(mnpr, f, indent=4)
-    print "MNPR version created successfully",
+    print("MNPR version created successfully", end=' ')
 
 
 def checkUpdates(directory):
@@ -105,7 +106,7 @@ def checkUpdates(directory):
     Args:
         directory (str): Directory of installed MNPR
     """
-    print "Checking for updates..."
+    print("Checking for updates...")
     # get local mnpr version
     localPath = os.path.join(directory, "version.json")
     with open(localPath, 'r') as f:
@@ -118,7 +119,7 @@ def checkUpdates(directory):
     try:
         downloader.retrieve(onlinePath, tempPath)
     except IOError:
-        print "Maya can't connect to the internet.",
+        print("Maya can't connect to the internet.", end=' ')
         return
     with open(tempPath, 'r') as f:
         onlineMNPR = json.load(f)
@@ -158,9 +159,9 @@ def checkUpdates(directory):
     for key in keys2Delete:
         onlineMNPR.pop(key)
 
-    print "LOCAL"
+    print("LOCAL")
     pprint.pprint(localMNPR)
-    print "\nONLINE"
+    print("\nONLINE")
     pprint.pprint(onlineMNPR)
 
     # compare the two versions
@@ -215,7 +216,7 @@ def checkUpdates(directory):
     reply = cmds.confirmDialog(title='Update is available', message=mString, button=['Yes', 'No'], defaultButton='Yes', cancelButton='No', dismissString='No', icn="information")
     # don't do anything
     if reply == "No":
-        print "Nothing has been updated",
+        print("Nothing has been updated", end=' ')
         return
 
     if restartMaya:
@@ -223,7 +224,7 @@ def checkUpdates(directory):
         mString += "No scenes/preferences will be saved upon closure, do you still wish to proceed?"
         reply = cmds.confirmDialog(title='Shelf update', message=mString, button=['Yes', 'No'], defaultButton='Yes', cancelButton='No', dismissString='No', icn="warning")
         if reply == "No":
-            print "Nothing has been updated",
+            print("Nothing has been updated", end=' ')
             return
 
     if updateMNPR(directory, files2Update, files2Delete):

--- a/scripts/mnpr_updater.py
+++ b/scripts/mnpr_updater.py
@@ -65,7 +65,7 @@ def updateMNPR(directory, files2Update, files2Delete):
         except:
             print("Couldn't remove {0}".format(filePath))
 
-    print("Update completed.", end=' ')
+    lib.printInfo("Update completed.")
     return True
 
 
@@ -97,7 +97,7 @@ def createVersion(directory):
     # write and save json info
     with open(path, 'w') as f:
         json.dump(mnpr, f, indent=4)
-    print("MNPR version created successfully", end=' ')
+    lib.printInfo("MNPR version created successfully")
 
 
 def checkUpdates(directory):
@@ -119,7 +119,7 @@ def checkUpdates(directory):
     try:
         downloader.retrieve(onlinePath, tempPath)
     except IOError:
-        print("Maya can't connect to the internet.", end=' ')
+        lib.printInfo("Maya can't connect to the internet.")
         return
     with open(tempPath, 'r') as f:
         onlineMNPR = json.load(f)
@@ -216,7 +216,7 @@ def checkUpdates(directory):
     reply = cmds.confirmDialog(title='Update is available', message=mString, button=['Yes', 'No'], defaultButton='Yes', cancelButton='No', dismissString='No', icn="information")
     # don't do anything
     if reply == "No":
-        print("Nothing has been updated", end=' ')
+        lib.printInfo("Nothing has been updated")
         return
 
     if restartMaya:
@@ -224,7 +224,7 @@ def checkUpdates(directory):
         mString += "No scenes/preferences will be saved upon closure, do you still wish to proceed?"
         reply = cmds.confirmDialog(title='Shelf update', message=mString, button=['Yes', 'No'], defaultButton='Yes', cancelButton='No', dismissString='No', icn="warning")
         if reply == "No":
-            print("Nothing has been updated", end=' ')
+            lib.printInfo("Nothing has been updated")
             return
 
     if updateMNPR(directory, files2Update, files2Delete):


### PR DESCRIPTION
Make the minimal, safe changes to make the codebase syntax compatible with both Python 2 and Python 3. Being syntax compatible does not mean that the port to Python 3 is complete.
* __futurize --stage1 -w .__ # http://python-future.org/futurize_cheatsheet.html
* manually fix up __basestring__, __long()__, __reload()__, and __xrange()__.